### PR TITLE
chore(pylint): update Python version support to 3.12+ and 3.13

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # s3cure.py - MinIO Bucket Creator 🚀
 
-[![Python](https://img.shields.io/badge/Python-3.6%2B-blue.svg)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](https://www.python.org/)
 [![MinIO](https://img.shields.io/badge/MinIO-Compatible-orange.svg)](https://min.io/)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 


### PR DESCRIPTION
Updated Python version support in the project:

- 🔄 Modified .github/workflows/pylint.yml to test against Python 3.12 and 3.13.
- 📝 Updated the README badge to reflect Python 3.12+ compatibility.

This change aligns the project with the latest Python versions and ensures compatibility with newer releases.